### PR TITLE
Fix some expected test data.

### DIFF
--- a/config/locales/en.incidents.yml
+++ b/config/locales/en.incidents.yml
@@ -19,6 +19,7 @@ en:
     cases:
       form:
         add_case: Add Client
+        delete_confirm: Really delete this client?
 
     initial_incident_reports:
       form:

--- a/spec/features/incidents/submit_dat_incident_report_spec.rb
+++ b/spec/features/incidents/submit_dat_incident_report_spec.rb
@@ -41,7 +41,7 @@ describe "DAT Incident Report", type: :feature, versions: true do
     expect(@incident.all_responder_assignments.size).to eq(3)
     expect(@incident.all_responder_assignments.map(&:person)).to match_array([@team_lead, @responder, @flex_responder])
 
-    expect(@incident.address).to eq("1663 Market Street")
+    expect(@incident.address).to eq("1663 Market St")
     expect(@incident.status).to eq('closed')
 
   end


### PR DESCRIPTION
It looks like some test data originating in commit 6532f228 uses
"1663 Market St" for address to be looked up in the simulated browser
search, but then expects "1663 Market Street" in the corresponding
incident report.  As a result, Travis CI builds are failing -- see:

 https://github.com/redcross/arcdata/pull/58
 https://travis-ci.org/redcross/arcdata/builds/103004438
 https://travis-ci.org/redcross/arcdata/builds/103004459
