### PR TITLE
Sync up code differences between Heroku and GitHub

### DIFF
--- a/app/controllers/incidents/import_controller.rb
+++ b/app/controllers/incidents/import_controller.rb
@@ -46,7 +46,6 @@ class Incidents::ImportController < ApplicationController
   def import_dispatch_v1(message, import_log)
     body = message['body']
     # Todo: move this to the importer where it belongs
-    puts body.inspect
     matches = body.match(/Account: (\d+)/i)
     if matches
       account_number = matches[1]

--- a/lib/incidents/dispatch_importer.rb
+++ b/lib/incidents/dispatch_importer.rb
@@ -147,7 +147,6 @@ class Incidents::DispatchImporter
     details, log = clean_body(body).split("============ Message Dispatch History ===================")
 
     data = run_matchers self.data_matchers, body
-    puts data.inspect
     log_items = log.split("\n\n").map {|item_text| run_matchers self.history_matchers, item_text}
     log_object = update_log_object data, log_items
 


### PR DESCRIPTION
The git commit SHA currently running on Heroku was not present in the
source tree of the repo on GitHub (probably the result of a local
change pushed to Heroku but not to GitHub).

This commit brings the changes extant on Heroku into the main repo. As
you can see the changes are minimal so the purpose of this is mostly to
document that it was done, rather than to preserve the inconsequential
changes.

These changes were retrieved by downloading the currently-running
source code slug from Heroku (via
https://github.com/heroku/heroku-slugs), copying the slug code over the
repo code, and committing the difference.