### PR TITLE
Allow Pubnub to use SSL.

### DIFF
--- a/lib/pubnub_client.rb
+++ b/lib/pubnub_client.rb
@@ -4,7 +4,8 @@ class PubnubClient
       subscribe_key: subscribe_key,
       publish_key: ENV['PUBNUB_PUBLISH_KEY'],
       origin: ENV['PUBNUB_ORIGIN'],
-      logger: Rails.logger
+      logger: Rails.logger,
+      ssl: true
       )
   end
 


### PR DESCRIPTION
Modify ruby settings to use SSL to allow PubNub to function.

https://www.pubnub.com/docs/ruby/api-reference-configuration

![pubnub](https://user-images.githubusercontent.com/324817/33451324-8c6cdcf2-d5c3-11e7-9a7d-1b786d8e5373.jpeg)