### PR TITLE
Fix admin page errors

### DIFF
--- a/app/admin/roster/roles.rb
+++ b/app/admin/roster/roles.rb
@@ -15,7 +15,7 @@ ActiveAdmin.register Roster::Role, as: 'Role' do
     column :name
     column :grant_name
     column :positions do |role|
-      safe_join(role.role_memberships.map{|pm| "#{pm.position.name} (#{pm.role_scopes.map(&:scope).join ','})"}, tag(:br))
+      safe_join(role.role_memberships.map{|pm| "#{pm.position.name if pm.position} (#{pm.role_scopes.map(&:scope).join ','})"}, tag(:br))
     end
     actions
   end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -226,3 +226,18 @@ ActiveAdmin.setup do |config|
     end
   end
 end
+
+module ActiveAdmin
+  module Views
+    class TableFor < Arbre::HTML::Table
+      protected
+      def is_boolean?(data, item)
+        if (item.respond_to? :has_attribute?) && (!item.class.ancestors.include? Core::SerializedColumns)
+          item.has_attribute?(data) &&
+            item.column_for_attribute(data) &&
+            item.column_for_attribute(data).type == :boolean
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix errors in #136 with custom serializers in ActiveAdmin by monkey-patching a method that calls `has_attribute?` which is overridden in the custom serializer in` arcdata_core`. Also implement a null check for the roles admin page, fixing an outstanding error there. Admin pages for Chapters, Scopes, and Roles should be visible after this fix