### PR TITLE
Exclude credentials errors from Sentry

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.excluded_exceptions += ['Cas::Client::InvalidCredentials']
+end


### PR DESCRIPTION
Closes #154. The Cas credential errors are really what push us over the free tier for Sentry. This excludes them from being reported