### PR TITLE
WIP: Increase chapter admin permissions

### DIFF
--- a/app/admin/ability.rb
+++ b/app/admin/ability.rb
@@ -49,25 +49,47 @@ class AdminAbility
     is_admin = person.has_role 'chapter_admin'
     if is_admin
       chapter = person.chapter_id
-      can :read, [Roster::Person, Roster::County, Roster::Position], chapter_id: chapter
-      can :impersonate, Roster::Person, chapter_id: chapter
-      can :manage, Logistics::Vehicle, chapter_id: chapter
-      can :manage, HomepageLink, chapter_id: chapter
+
+      can :manage, Incidents::CallLog, chapter_id: chapter
+      can :manage, Incidents::Deployment, person: {chapter_id: chapter}
+      can :manage, Incidents::DispatchLog, chapter_id: chapter
+      # can :manage, Incidents::NumberSequence, chapter_id: chapter
+      # can :manage, Incidents::PriceListItem, chapter_id: chapter
       can :new, Incidents::ReportSubscription
       can :manage, Incidents::ReportSubscription, person: {chapter_id: chapter}
       can [:test_report, :send_report, :new], Incidents::ReportSubscription
-
+      can :manage, Incidents::ResponderMessage, chapter_id: chapter
+      can :manage, Incidents::Scope, chapter_id: chapter
+      can :manage, Incidents::Territory, chapter_id: chapter
       can :manage, Incidents::Notifications::Event, chapter_id: chapter
       can :manage, Incidents::Notifications::Role, chapter_id: chapter
 
-      can [:read, :update], Scheduler::DispatchConfig, chapter_id: chapter
-      can :read, Incidents::DispatchLog, chapter_id: chapter
+      can :manage, Logistics::Vehicle, chapter_id: chapter
 
-      can :manage, Incidents::Territory, chapter_id: chapter
+      can :manage, Partners::Partner, chapter_id: chapter
 
+      # can :manage, Roster::CellCarrier, chapter_id: chapter
+      can :manage, Roster::Chapter, id: chapter
+      can :manage, Roster::County, chapter_id: chapter
+      can :manage, Roster::Person, chapter_id: chapter
+      can :manage, Roster::Position, chapter_id: chapter
       can :manage, RegionAdminProxy do |region|
         region.region_id.nil? || region.region_id == chapter
       end
+      # can :manage, Roster::Role, chapter_id: chapter
+
+      can :manage, Scheduler::DispatchConfig, chapter_id: chapter
+      can :manage, Scheduler::ShiftCategory, chapter_id: chapter
+      can :manage, Scheduler::ShiftGroup, chapter_id: chapter
+      can :manage, Scheduler::Shift, county: {chapter_id: chapter}
+    
+      # can :manage, DataFilter, chapter_id: chapter
+      can :manage, HomepageLink, chapter_id: chapter
+      # can :manage, Core::JobLog, chapter_id: chapter
+      # can :manage, Delayed::Job, chapter_id: chapter
+      can :manage, Lookup, chapter_id: chapter
+      can :manage, MOTD, chapter_id: chapter
+      # can :manage, NamedQuery, chapter_id: chapter
     end
   end
 

--- a/app/admin/scheduler/people.rb
+++ b/app/admin/scheduler/people.rb
@@ -34,7 +34,11 @@ ActiveAdmin.register Roster::Person, as: 'Person' do
     f.actions
     f.inputs do
       f.has_many :position_memberships do |form|
-        form.input :position, collection: (f.object.chapter && f.object.chapter.positions)
+        if current_user.has_role 'chapter_config'
+          form.input :position, collection: Roster::Position.all
+        else
+          form.input :position, collection: (f.object.chapter && f.object.chapter.positions)
+        end
         form.input :persistent
         form.input :_destroy, as: :boolean, label: "Remove"
       end


### PR DESCRIPTION
Will close #166. Adds additional permissions to Chapter Admins and lets users with the superuser "Chapter Config" role add it to other users.

Doesn't cover the following permissions because they aren't scoped by chapter, but if it's alright for any chapter admin to edit them that can be modified here:

* Number sequences
* Price list items
* Cell carries
* Roles
* Data filters
* Job logs
* Delayed jobs
* Named queries

@OhMcGoo this is live on the staging site (https://arcdata-staging.herokuapp.com/), let me know if it's what you had in mind