### PR TITLE
Add county to dispatched incident parameters

### DIFF
--- a/app/models/incidents/new_dispatch_service.rb
+++ b/app/models/incidents/new_dispatch_service.rb
@@ -19,7 +19,7 @@ class Incidents::NewDispatchService
   def create_incident
     @incident = Incidents::Incident.create! do |i|
       i.status = 'open'
-      [:chapter_id, :territory_id, :incident_type, :address, :city, :state, :zip, :lat, :lng].each do |attr|
+      [:chapter_id, :territory_id, :incident_type, :address, :city, :county, :state, :zip, :lat, :lng].each do |attr|
         i[attr] = call_log[attr]
       end
       i.date = i.chapter.time_zone.today


### PR DESCRIPTION
Incidents created from call logs through `Incidents::NewDispatchServicenow` supply the county field in `create_incident`. Closes #176