### PR TITLE
Update DAT Incident labels

### DIFF
--- a/app/views/incidents/dat_incidents/_panel_services.html.haml
+++ b/app/views/incidents/dat_incidents/_panel_services.html.haml
@@ -4,9 +4,9 @@
   =f.semantic_errors :services
   =hidden_field_tag "incidents_dat_incident[services][]", ''
   .form-group
-    %label.form-label Client Financial Assistance
+    %label.form-label Direct Client Assistance
     .form-wrapper
-      - {"None" => 'none', "Emergency Housing" => 'housing', 'Food' => 'food', 'Clothing' => 'clothing', 'Medication' => 'medication'}.each do |label, val|
+      - {"Lodging" => 'housing', "Immediate" => 'immediate', "None" => 'none'}.each do |label, val|
         - local_services << val
         .checkbox
           %label
@@ -15,7 +15,7 @@
   .form-group
     %label.form-label Other Assistance
     .form-wrapper
-      - other_services = {"Mental Health Support" => 'mental_health', 'Translation' => 'translation', "Snacks for Clients" => 'client_snacks', "Spiritual Care" => 'spiritual_care'}
+      - other_services = {"Health Services" => 'health', "Mental Health" => 'mental_health', "Spiritual Care" => 'spiritual_care', 'Translation' => 'translation'}
       - other_services["Referrals"] = 'referrals' if f.object.incident.chapter.incidents_report_advanced_details
       - other_services.each do |label, val|
         - local_services << val


### PR DESCRIPTION
Closes #174. Updated based on the description in the issue, and tested this out. It doesn't look like the values are used anywhere else where they might break something