### PR TITLE
Update damage assessment fields

### DIFF
--- a/app/assets/javascripts/incidents/dat_incidents.js.coffee
+++ b/app/assets/javascripts/incidents/dat_incidents.js.coffee
@@ -86,7 +86,7 @@ class window.DatIncidentsFormController
       if (data.hide)
         $(data.hide).not(shown).collapse('hide')
 
-    @da_fields = ['incidents_dat_incident_units_affected', 'incidents_dat_incident_units_minor', 'incidents_dat_incident_units_major', 'incidents_dat_incident_units_destroyed']
+    @da_fields = ['incidents_dat_incident_units_not_livable', 'incidents_dat_incident_units_livable', 'incidents_dat_incident_units_affected', 'incidents_dat_incident_units_minor', 'incidents_dat_incident_units_major', 'incidents_dat_incident_units_destroyed']
     $(document).on 'change', @da_fields.map((el)->"##{el}").join(","), (evt) =>
       total = 0
       @da_fields.forEach (el) ->

--- a/app/controllers/incidents/dat_incidents_controller.rb
+++ b/app/controllers/incidents/dat_incidents_controller.rb
@@ -143,6 +143,7 @@ class Incidents::DatIncidentsController < Incidents::BaseController
              :incident_type, :incident_description, :narrative_brief, :narrative,
              :num_people_injured, :num_people_hospitalized, :num_people_deceased, :num_people_missing,
              :responder_notified, :responder_arrived, :responder_departed,
+             :units_not_livable, :units_livable,
              :units_affected, :units_minor, :units_major, :units_destroyed, :units_unknown,
              :structure_type, :num_first_responders,
              :suspicious_fire, :injuries_black, :injuries_red, :injuries_yellow,

--- a/app/models/incidents/dat_incident.rb
+++ b/app/models/incidents/dat_incident.rb
@@ -13,7 +13,7 @@ class Incidents::DatIncident < Incidents::DataModel
   end
 
   assignable_values_for :structure_type, allow_blank: true do
-    %w(single_family_home apartment sro mobile_home commercial none)
+    %w(single_family_home multi_family_home apartment sro mobile_home commercial none)
   end
 
   assignable_values_for :vacate_type, allow_blank: true do
@@ -46,7 +46,7 @@ class Incidents::DatIncident < Incidents::DataModel
   end
 
   def units_total
-    [units_affected, units_minor, units_major, units_destroyed].compact.sum
+    [units_not_livable, units_livable, units_affected, units_minor, units_major, units_destroyed].compact.sum
   end
 
   def cant_update_incident

--- a/app/models/incidents/dat_incident.rb
+++ b/app/models/incidents/dat_incident.rb
@@ -78,4 +78,12 @@ class Incidents::DatIncident < Incidents::DataModel
     end
   end
 
+  # Red Cross changes the damage assessments in July of 2020, but still wanted
+  # to display the old ones for legacy incidents.
+  def has_old_damage_assessments
+    (units_affected.present? && units_affected > 0) ||
+      (units_minor.present? && units_minor > 0) ||
+      (units_major.present? && units_major > 0) ||
+      (units_destroyed.present? && units_destroyed > 0)
+  end
 end

--- a/app/models/incidents/validators/complete_report_validator.rb
+++ b/app/models/incidents/validators/complete_report_validator.rb
@@ -4,7 +4,7 @@ class Incidents::Validators::CompleteReportValidator < DelegatedValidator
 
   validates :incident_call_type, :structure_type, presence: true
 
-  validates :units_affected, :units_minor, :units_major, :units_destroyed, presence: true, numericality: {:greater_than_or_equal_to => 0, allow_blank: true}
+  validates :units_livable, :units_not_livable, presence: true, numericality: {:greater_than_or_equal_to => 0, allow_blank: true}
   validates :num_people_injured, :num_people_hospitalized, :num_people_deceased, presence: true, numericality: {:greater_than_or_equal_to => 0, allow_blank: true}
 
   validates :completed_by, :vehicle_uses, presence: true

--- a/app/views/incidents/dat_incidents/_panel_damage_assessment.html.haml
+++ b/app/views/incidents/dat_incidents/_panel_damage_assessment.html.haml
@@ -1,9 +1,11 @@
 =f.inputs "Damage Assessment" do
   =f.input :structure_type, as: :assignable_select, required: true
-  =f.input :units_destroyed
-  =f.input :units_major
-  =f.input :units_minor
-  =f.input :units_affected
+  =f.input :units_not_livable
+  =f.input :units_livable
+  =f.input :units_destroyed, required: false
+  =f.input :units_major, required: false
+  =f.input :units_minor, required: false
+  =f.input :units_affected, required: false
   -if f.object.incident.region.incidents_report_advanced_details
     =f.input :units_unknown, label: "Units Undefined/Unknown"
   =f.input :units_total, input_html: {readonly: true, editable: false}

--- a/app/views/incidents/dat_incidents/_panel_damage_assessment.html.haml
+++ b/app/views/incidents/dat_incidents/_panel_damage_assessment.html.haml
@@ -2,10 +2,12 @@
   =f.input :structure_type, as: :assignable_select, required: true
   =f.input :units_not_livable
   =f.input :units_livable
-  =f.input :units_destroyed, required: false
-  =f.input :units_major, required: false
-  =f.input :units_minor, required: false
-  =f.input :units_affected, required: false
+  -# TODO Remove this check after 2020-08-01
+  -if f.object.incident.date < Date.parse('2020-07-01')
+    =f.input :units_destroyed, required: false
+    =f.input :units_major, required: false
+    =f.input :units_minor, required: false
+    =f.input :units_affected, required: false
   -if f.object.incident.region.incidents_report_advanced_details
     =f.input :units_unknown, label: "Units Undefined/Unknown"
   =f.input :units_total, input_html: {readonly: true, editable: false}

--- a/app/views/incidents/incidents/_details_da.html.haml
+++ b/app/views/incidents/incidents/_details_da.html.haml
@@ -17,11 +17,15 @@
     %td.table-nested-container(colspan="2")
       %table.table.table-bordered.table-condensed.table-nested
         %tr
-          %th(style="width: 25%") Affected
-          %th(style="width: 25%") Minor
-          %th(style="width: 25%") Major
-          %th(style="width: 25%") Destroyed
+          %th(style="width: 16.6%") Not Livable
+          %th(style="width: 16.6%") Livable
+          %th(style="width: 16.6%") Affected
+          %th(style="width: 16.6%") Minor
+          %th(style="width: 16.6%") Major
+          %th(style="width: 16.6%") Destroyed
         %tr
+          %td=dat.units_not_livable
+          %td=dat.units_livable
           %td=dat.units_affected
           %td=dat.units_minor
           %td=dat.units_major

--- a/app/views/incidents/incidents/_details_da.html.haml
+++ b/app/views/incidents/incidents/_details_da.html.haml
@@ -19,14 +19,16 @@
         %tr
           %th(style="width: 16.6%") Not Livable
           %th(style="width: 16.6%") Livable
-          %th(style="width: 16.6%") Affected
-          %th(style="width: 16.6%") Minor
-          %th(style="width: 16.6%") Major
-          %th(style="width: 16.6%") Destroyed
+          - if dat.has_old_damage_assessments
+            %th(style="width: 16.6%") Affected
+            %th(style="width: 16.6%") Minor
+            %th(style="width: 16.6%") Major
+            %th(style="width: 16.6%") Destroyed
         %tr
           %td=dat.units_not_livable
           %td=dat.units_livable
-          %td=dat.units_affected
-          %td=dat.units_minor
-          %td=dat.units_major
-          %td=dat.units_destroyed
+          - if dat.has_old_damage_assessments
+            %td=dat.units_affected
+            %td=dat.units_minor
+            %td=dat.units_major
+            %td=dat.units_destroyed

--- a/app/views/incidents/notifications/mailer/incident_report_filed.html.haml
+++ b/app/views/incidents/notifications/mailer/incident_report_filed.html.haml
@@ -29,7 +29,7 @@
   Units: #{dat.units_total}
 
 %p
-  Damage Assessment: #{dat.units_destroyed} destroyed, #{dat.units_major} major, #{dat.units_minor} minor, #{dat.units_affected} affected
+  Damage Assessment: #{dat.units_not_livable} not livable, #{dat.units_livable} livable, #{dat.units_destroyed} destroyed, #{dat.units_major} major, #{dat.units_minor} minor, #{dat.units_affected} affected
 
 %p
   Services Provided: #{@incident.services_description}

--- a/db/migrate/20181221032826_add_units_not_livable_units_livable_to_dat_incident.rb
+++ b/db/migrate/20181221032826_add_units_not_livable_units_livable_to_dat_incident.rb
@@ -1,0 +1,6 @@
+class AddUnitsNotLivableUnitsLivableToDatIncident < ActiveRecord::Migration
+  def change
+    add_column :incidents_dat_incidents, :units_not_livable, :integer
+    add_column :incidents_dat_incidents, :units_livable, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -380,6 +380,8 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.integer  "num_people_missing"
     t.string   "hazardous_materials"
     t.integer  "units_unknown"
+    t.integer  "units_not_livable"
+    t.integer  "units_livable"
   end
 
   add_index "incidents_dat_incidents", ["incident_id"], name: "index_incidents_dat_incidents_on_incident_id", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,14 +20,14 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   enable_extension "tablefunc"
 
   create_table "active_admin_comments", force: :cascade do |t|
-    t.string   "resource_id",   null: false
-    t.string   "resource_type", null: false
+    t.string   "resource_id",   limit: 255, null: false
+    t.string   "resource_type", limit: 255, null: false
     t.integer  "author_id"
-    t.string   "author_type"
+    t.string   "author_type",   limit: 255
     t.text     "body"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "namespace"
+    t.string   "namespace",     limit: 255
   end
 
   add_index "active_admin_comments", ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
 
   create_table "api_clients", force: :cascade do |t|
-    t.string   "name"
-    t.string   "app_token"
-    t.string   "app_secret"
+    t.string   "name",       limit: 255
+    t.string   "app_token",  limit: 255
+    t.string   "app_secret", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "connect_access_tokens", force: :cascade do |t|
     t.integer  "account_id"
     t.integer  "client_id"
-    t.string   "token"
+    t.string   "token",      limit: 255
     t.datetime "expires_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -84,9 +84,9 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "connect_authorizations", force: :cascade do |t|
     t.integer  "account_id"
     t.integer  "client_id"
-    t.string   "code"
-    t.string   "nonce"
-    t.string   "redirect_uri"
+    t.string   "code",         limit: 255
+    t.string   "nonce",        limit: 255
+    t.string   "redirect_uri", limit: 255
     t.datetime "expires_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -96,16 +96,16 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "connect_clients", force: :cascade do |t|
     t.integer  "account_id"
-    t.string   "identifier"
-    t.string   "secret"
-    t.string   "name"
-    t.string   "jwks_uri"
-    t.string   "sector_identifier"
-    t.string   "redirect_uris"
-    t.boolean  "dynamic",             default: false
-    t.boolean  "native",              default: false
-    t.boolean  "ppid",                default: false
-    t.boolean  "superapp",            default: false
+    t.string   "identifier",          limit: 255
+    t.string   "secret",              limit: 255
+    t.string   "name",                limit: 255
+    t.string   "jwks_uri",            limit: 255
+    t.string   "sector_identifier",   limit: 255
+    t.string   "redirect_uris",       limit: 255
+    t.boolean  "dynamic",                         default: false
+    t.boolean  "native",                          default: false
+    t.boolean  "ppid",                            default: false
+    t.boolean  "superapp",                        default: false
     t.datetime "expires_at"
     t.text     "raw_registered_json"
     t.datetime "created_at"
@@ -137,7 +137,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "connect_id_tokens", force: :cascade do |t|
     t.integer  "account_id"
     t.integer  "client_id"
-    t.string   "nonce"
+    t.string   "nonce",      limit: 255
     t.datetime "expires_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -145,8 +145,8 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "connect_pairwise_pseudonymous_identifiers", force: :cascade do |t|
     t.integer  "account_id"
-    t.string   "identifier"
-    t.string   "sector_identifier"
+    t.string   "identifier",        limit: 255
+    t.string   "sector_identifier", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   end
 
   create_table "connect_scopes", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -166,23 +166,23 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "connect_scopes", ["name"], name: "index_connect_scopes_on_name", unique: true, using: :btree
 
   create_table "data_filters", force: :cascade do |t|
-    t.string   "model"
-    t.string   "field"
-    t.string   "pattern_raw"
+    t.string   "model",       limit: 255
+    t.string   "field",       limit: 255
+    t.string   "pattern_raw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
+    t.integer  "priority",               default: 0, null: false
+    t.integer  "attempts",               default: 0, null: false
+    t.text     "handler",                            null: false
     t.text     "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string   "locked_by",  limit: 255
+    t.string   "queue",      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -191,21 +191,21 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "homepage_link_roles", force: :cascade do |t|
     t.integer "homepage_link_id"
-    t.string  "role_scope"
+    t.string  "role_scope",       limit: 255
   end
 
   create_table "homepage_links", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "name"
+    t.string   "name",              limit: 255
     t.text     "description"
-    t.string   "icon"
-    t.string   "url"
-    t.string   "file_file_name"
-    t.string   "file_content_type"
+    t.string   "icon",              limit: 255
+    t.string   "url",               limit: 255
+    t.string   "file_file_name",    limit: 255
+    t.string   "file_content_type", limit: 255
     t.integer  "file_file_size"
     t.datetime "file_updated_at"
     t.integer  "ordinal"
-    t.string   "group"
+    t.string   "group",             limit: 255
     t.integer  "group_ordinal"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -214,12 +214,12 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "homepage_links", ["region_id"], name: "index_homepage_links_on_region_id", using: :btree
 
   create_table "incidents_attachments", force: :cascade do |t|
-    t.integer  "incident_id",       null: false
-    t.string   "attachment_type"
-    t.string   "name"
+    t.integer  "incident_id",                   null: false
+    t.string   "attachment_type",   limit: 255
+    t.string   "name",              limit: 255
     t.text     "description"
-    t.string   "file_file_name"
-    t.string   "file_content_type"
+    t.string   "file_file_name",    limit: 255
+    t.string   "file_content_type", limit: 255
     t.integer  "file_file_size"
     t.datetime "file_updated_at"
   end
@@ -229,18 +229,18 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "incidents_call_logs", force: :cascade do |t|
     t.integer  "region_id"
     t.integer  "dispatching_region_id"
-    t.string   "call_type"
-    t.string   "contact_name"
-    t.string   "contact_number"
-    t.string   "address_entry"
-    t.string   "address"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
-    t.string   "county"
+    t.string   "call_type",             limit: 255
+    t.string   "contact_name",          limit: 255
+    t.string   "contact_number",        limit: 255
+    t.string   "address_entry",         limit: 255
+    t.string   "address",               limit: 255
+    t.string   "city",                  limit: 255
+    t.string   "state",                 limit: 255
+    t.string   "zip",                   limit: 255
+    t.string   "county",                limit: 255
     t.float    "lat"
     t.float    "lng"
-    t.string   "incident_type"
+    t.string   "incident_type",         limit: 255
     t.text     "services_requested"
     t.integer  "num_displaced"
     t.text     "referral_reason"
@@ -257,18 +257,18 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_cas_cases", force: :cascade do |t|
     t.integer  "cas_incident_id"
-    t.string   "case_number"
+    t.string   "case_number",         limit: 255
     t.integer  "num_clients"
-    t.string   "family_name"
+    t.string   "family_name",         limit: 255
     t.date     "case_last_updated"
     t.date     "case_opened"
     t.boolean  "case_is_open"
-    t.string   "language"
+    t.string   "language",            limit: 255
     t.text     "narrative"
-    t.string   "address"
-    t.string   "city"
-    t.string   "state"
-    t.string   "post_incident_plans"
+    t.string   "address",             limit: 255
+    t.string   "city",                limit: 255
+    t.string   "state",               limit: 255
+    t.string   "post_incident_plans", limit: 255
     t.text     "notes"
     t.datetime "last_import"
     t.datetime "created_at"
@@ -281,12 +281,12 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "incidents_cas_cases", ["case_number"], name: "index_incidents_cas_cases_on_case_number", unique: true, using: :btree
 
   create_table "incidents_cas_incidents", force: :cascade do |t|
-    t.string   "dr_number"
-    t.string   "cas_incident_number"
-    t.string   "cas_name"
+    t.string   "dr_number",                 limit: 255
+    t.string   "cas_incident_number",       limit: 255
+    t.string   "cas_name",                  limit: 255
     t.integer  "dr_level"
     t.boolean  "is_dr"
-    t.string   "county"
+    t.string   "county",                    limit: 255
     t.integer  "cases_opened"
     t.integer  "cases_open"
     t.integer  "cases_closed"
@@ -301,8 +301,8 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "region_id"
-    t.string   "region_code"
-    t.boolean  "ignore_incident",           default: false, null: false
+    t.string   "region_code",               limit: 255
+    t.boolean  "ignore_incident",                       default: false, null: false
   end
 
   add_index "incidents_cas_incidents", ["cas_incident_number"], name: "index_incidents_cas_incidents_on_cas_incident_number", unique: true, using: :btree
@@ -321,36 +321,36 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_cases", force: :cascade do |t|
     t.integer  "incident_id"
-    t.string   "cas_case_number"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "address"
-    t.string   "unit"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
+    t.string   "cas_case_number", limit: 255
+    t.string   "first_name",      limit: 255
+    t.string   "last_name",       limit: 255
+    t.string   "address",         limit: 255
+    t.string   "unit",            limit: 255
+    t.string   "city",            limit: 255
+    t.string   "state",           limit: 255
+    t.string   "zip",             limit: 255
     t.float    "lat"
     t.float    "lng"
-    t.string   "phone_number"
+    t.string   "phone_number",    limit: 255
     t.integer  "num_adults"
     t.integer  "num_children"
     t.decimal  "total_amount"
     t.text     "notes"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "cac_masked"
+    t.string   "cac_masked",      limit: 255
   end
 
   add_index "incidents_cases", ["incident_id"], name: "index_incidents_cases_on_incident_id", using: :btree
 
   create_table "incidents_dat_incidents", force: :cascade do |t|
-    t.integer  "incident_id",             null: false
-    t.string   "incident_call_type"
-    t.string   "verified_by"
+    t.integer  "incident_id",                         null: false
+    t.string   "incident_call_type",      limit: 255
+    t.string   "verified_by",             limit: 255
     t.integer  "num_people_injured"
     t.integer  "num_people_hospitalized"
     t.integer  "num_people_deceased"
-    t.string   "cross_street"
+    t.string   "cross_street",            limit: 255
     t.integer  "units_affected"
     t.integer  "units_minor"
     t.integer  "units_major"
@@ -358,7 +358,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.text     "services"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "structure_type"
+    t.string   "structure_type",          limit: 255
     t.integer  "completed_by_id"
     t.text     "languages"
     t.hstore   "resources"
@@ -367,18 +367,18 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.integer  "injuries_black"
     t.integer  "injuries_red"
     t.integer  "injuries_yellow"
-    t.string   "where_started"
+    t.string   "where_started",           limit: 255
     t.datetime "under_control_at"
-    t.string   "box"
+    t.string   "box",                     limit: 255
     t.datetime "box_at"
-    t.string   "battalion"
+    t.string   "battalion",               limit: 255
     t.integer  "num_alarms"
-    t.string   "size_up"
+    t.string   "size_up",                 limit: 255
     t.integer  "num_exposures"
-    t.string   "vacate_type"
-    t.string   "vacate_number"
+    t.string   "vacate_type",             limit: 255
+    t.string   "vacate_number",           limit: 255
     t.integer  "num_people_missing"
-    t.string   "hazardous_materials"
+    t.string   "hazardous_materials",     limit: 255
     t.integer  "units_unknown"
     t.integer  "units_not_livable"
     t.integer  "units_livable"
@@ -388,11 +388,11 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_deployments", force: :cascade do |t|
     t.integer  "person_id"
-    t.string   "gap"
-    t.string   "group"
-    t.string   "activity"
-    t.string   "position"
-    t.string   "qual"
+    t.string   "gap",             limit: 255
+    t.string   "group",           limit: 255
+    t.string   "activity",        limit: 255
+    t.string   "position",        limit: 255
+    t.string   "qual",            limit: 255
     t.date     "date_first_seen"
     t.date     "date_last_seen"
     t.datetime "created_at"
@@ -402,9 +402,9 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_disasters", force: :cascade do |t|
     t.integer  "vc_incident_id"
-    t.string   "dr_number"
+    t.string   "dr_number",      limit: 255
     t.integer  "fiscal_year"
-    t.string   "name"
+    t.string   "name",           limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -412,10 +412,10 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "incidents_dispatch_log_items", force: :cascade do |t|
     t.integer  "dispatch_log_id"
     t.datetime "action_at"
-    t.string   "action_type"
-    t.string   "recipient"
-    t.string   "operator"
-    t.string   "result"
+    t.string   "action_type",     limit: 255
+    t.string   "recipient",       limit: 255
+    t.string   "operator",        limit: 255
+    t.string   "result",          limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -423,26 +423,26 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "incidents_dispatch_log_items", ["dispatch_log_id"], name: "index_incidents_dispatch_log_items_on_dispatch_log_id", using: :btree
 
   create_table "incidents_dispatch_logs", force: :cascade do |t|
-    t.string   "incident_number"
+    t.string   "incident_number",    limit: 255
     t.integer  "region_id"
     t.integer  "incident_id"
     t.datetime "received_at"
     t.datetime "delivered_at"
-    t.string   "delivered_to"
-    t.string   "incident_type"
-    t.string   "address"
-    t.string   "cross_street"
-    t.string   "county"
-    t.string   "displaced"
-    t.string   "services_requested"
-    t.string   "agency"
-    t.string   "contact_name"
-    t.string   "contact_phone"
-    t.string   "caller_id"
+    t.string   "delivered_to",       limit: 255
+    t.string   "incident_type",      limit: 255
+    t.string   "address",            limit: 255
+    t.string   "cross_street",       limit: 255
+    t.string   "county",             limit: 255
+    t.string   "displaced",          limit: 255
+    t.string   "services_requested", limit: 255
+    t.string   "agency",             limit: 255
+    t.string   "contact_name",       limit: 255
+    t.string   "contact_phone",      limit: 255
+    t.string   "caller_id",          limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "state"
-    t.string   "message_number"
+    t.string   "state",              limit: 255
+    t.string   "message_number",     limit: 255
   end
 
   add_index "incidents_dispatch_logs", ["incident_id"], name: "index_incidents_dispatch_logs_on_incident_id", using: :btree
@@ -451,7 +451,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "incidents_event_logs", force: :cascade do |t|
     t.integer  "incident_id"
     t.integer  "person_id"
-    t.string   "event"
+    t.string   "event",       limit: 255
     t.datetime "event_time"
     t.text     "message"
     t.datetime "created_at"
@@ -466,45 +466,45 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_incidents", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "incident_number"
-    t.string   "incident_type"
-    t.string   "cas_event_number"
+    t.string   "incident_number",             limit: 255
+    t.string   "incident_type",               limit: 255
+    t.string   "cas_event_number",            limit: 255
     t.date     "date"
     t.integer  "num_adults"
     t.integer  "num_children"
     t.integer  "num_families"
     t.integer  "num_cases"
-    t.string   "incident_description"
+    t.string   "incident_description",        limit: 255
     t.text     "narrative_brief"
     t.text     "narrative"
-    t.string   "address"
-    t.string   "cross_street"
-    t.string   "neighborhood"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
+    t.string   "address",                     limit: 255
+    t.string   "cross_street",                limit: 255
+    t.string   "neighborhood",                limit: 255
+    t.string   "city",                        limit: 255
+    t.string   "state",                       limit: 255
+    t.string   "zip",                         limit: 255
     t.float    "lat"
     t.float    "lng"
-    t.string   "idat_incident_id"
-    t.string   "idat_incident_rev"
+    t.string   "idat_incident_id",            limit: 255
+    t.string   "idat_incident_rev",           limit: 255
     t.datetime "last_idat_sync"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "last_no_incident_warning"
     t.boolean  "ignore_incident_report"
-    t.boolean  "evac_partner_used",           default: false
-    t.boolean  "hotel_partner_used",          default: false
-    t.boolean  "shelter_partner_used",        default: false
-    t.boolean  "feeding_partner_used",        default: false
+    t.boolean  "evac_partner_used",                       default: false
+    t.boolean  "hotel_partner_used",                      default: false
+    t.boolean  "shelter_partner_used",                    default: false
+    t.boolean  "feeding_partner_used",                    default: false
     t.integer  "shift_territory_id"
-    t.string   "county"
-    t.string   "status",                                      null: false
+    t.string   "county",                      limit: 255
+    t.string   "status",                      limit: 255,                 null: false
     t.date     "response_date"
     t.integer  "notification_level_id"
     t.text     "notification_level_message"
-    t.string   "recruitment_message"
+    t.string   "recruitment_message",         limit: 255
     t.integer  "cas_event_id"
-    t.boolean  "address_directly_entered",    default: false, null: false
+    t.boolean  "address_directly_entered",                default: false, null: false
     t.integer  "response_territory_id"
     t.integer  "current_dispatch_contact_id"
     t.datetime "dispatch_contact_due_at"
@@ -521,11 +521,11 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.integer  "completed_by_id"
     t.integer  "approved_by_id"
     t.boolean  "budget_exceeded"
-    t.string   "trend"
-    t.string   "triggers",              array: true
+    t.string   "trend",                 limit: 255
+    t.string   "triggers",              limit: 255, array: true
     t.integer  "estimated_units"
     t.integer  "estimated_individuals"
-    t.string   "expected_services",     array: true
+    t.string   "expected_services",     limit: 255, array: true
     t.boolean  "significant_media"
     t.boolean  "safety_concerns"
     t.boolean  "weather_concerns"
@@ -539,10 +539,10 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_notifications_events", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "name"
-    t.string   "description"
-    t.string   "event_type"
-    t.string   "event"
+    t.string   "name",        limit: 255
+    t.string   "description", limit: 255
+    t.string   "event_type",  limit: 255
+    t.string   "event",       limit: 255
     t.integer  "ordinal"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -552,8 +552,8 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_notifications_role_scopes", force: :cascade do |t|
     t.integer  "role_id"
-    t.string   "level"
-    t.string   "value"
+    t.string   "level",                 limit: 255
+    t.string   "value",                 limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "response_territory_id"
@@ -563,7 +563,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_notifications_roles", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "name"
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -585,7 +585,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "incidents_notifications_triggers", force: :cascade do |t|
     t.integer  "role_id"
     t.integer  "event_id"
-    t.string   "template"
+    t.string   "template",   limit: 255
     t.boolean  "use_sms"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -595,16 +595,16 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "incidents_notifications_triggers", ["role_id"], name: "index_incidents_notifications_triggers_on_role_id", using: :btree
 
   create_table "incidents_number_sequences", force: :cascade do |t|
-    t.string  "name"
+    t.string  "name",           limit: 255
     t.integer "current_year"
     t.integer "current_number"
-    t.string  "format"
+    t.string  "format",         limit: 255
   end
 
   create_table "incidents_partner_uses", force: :cascade do |t|
     t.integer  "incident_id"
     t.integer  "partner_id"
-    t.string   "role"
+    t.string   "role",         limit: 255
     t.decimal  "hotel_rate"
     t.integer  "hotel_rooms"
     t.integer  "meals_served"
@@ -617,24 +617,24 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_price_list_items", force: :cascade do |t|
     t.integer  "item_class"
-    t.string   "name"
-    t.string   "type"
+    t.string   "name",        limit: 255
+    t.string   "type",        limit: 255
     t.decimal  "unit_price"
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "enabled",     default: true, null: false
+    t.boolean  "enabled",                 default: true, null: false
   end
 
   create_table "incidents_report_subscriptions", force: :cascade do |t|
     t.integer  "person_id"
     t.integer  "shift_territory_id"
-    t.string   "report_type"
-    t.boolean  "persistent",         default: false
+    t.string   "report_type",        limit: 255
+    t.boolean  "persistent",                     default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.hstore   "options"
-    t.string   "frequency"
+    t.string   "frequency",          limit: 255
     t.date     "last_sent"
     t.integer  "scope_id"
   end
@@ -645,11 +645,11 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "incidents_responder_assignments", force: :cascade do |t|
     t.integer  "person_id"
     t.integer  "incident_id"
-    t.string   "role"
-    t.string   "response"
+    t.string   "role",              limit: 255
+    t.string   "response",          limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "was_flex",          default: false
+    t.boolean  "was_flex",                      default: false
     t.float    "driving_distance"
     t.datetime "dispatched_at"
     t.datetime "on_scene_at"
@@ -665,12 +665,12 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.integer  "incident_id"
     t.integer  "responder_assignment_id"
     t.integer  "in_reply_to_id"
-    t.string   "direction"
-    t.string   "local_number"
-    t.string   "remote_number"
+    t.string   "direction",               limit: 255
+    t.string   "local_number",            limit: 255
+    t.string   "remote_number",           limit: 255
     t.text     "message"
     t.boolean  "acknowledged"
-    t.string   "status"
+    t.string   "status",                  limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -681,7 +681,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "incidents_responder_recruitments", force: :cascade do |t|
     t.integer  "incident_id"
     t.integer  "person_id"
-    t.string   "response"
+    t.string   "response",            limit: 255
     t.integer  "outbound_message_id"
     t.integer  "inbound_message_id"
     t.datetime "created_at"
@@ -692,14 +692,14 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_response_territories", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "name"
+    t.string   "name",                 limit: 255
     t.boolean  "enabled"
     t.boolean  "is_default"
-    t.string   "counties",             array: true
-    t.string   "cities",               array: true
-    t.string   "zip_codes",            array: true
-    t.string   "dispatch_number"
-    t.string   "non_disaster_number"
+    t.string   "counties",             limit: 255, array: true
+    t.string   "cities",               limit: 255, array: true
+    t.string   "zip_codes",            limit: 255, array: true
+    t.string   "dispatch_number",      limit: 255
+    t.string   "non_disaster_number",  limit: 255
     t.text     "special_instructions"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -717,10 +717,10 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "incidents_scopes", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "url_slug"
-    t.string   "abbrev"
-    t.string   "short_name"
-    t.string   "name"
+    t.string   "url_slug",   limit: 255
+    t.string   "abbrev",     limit: 255
+    t.string   "short_name", limit: 255
+    t.string   "name",       limit: 255
     t.hstore   "config"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -746,12 +746,12 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "incidents_vehicle_uses", ["vehicle_id"], name: "index_incidents_vehicle_uses_on_vehicle_id", using: :btree
 
   create_table "job_logs", force: :cascade do |t|
-    t.string   "controller"
-    t.string   "name"
-    t.string   "url"
-    t.string   "result"
-    t.string   "message_subject"
-    t.string   "file_name"
+    t.string   "controller",        limit: 255
+    t.string   "name",              limit: 255
+    t.string   "url",               limit: 255
+    t.string   "result",            limit: 255
+    t.string   "message_subject",   limit: 255
+    t.string   "file_name",         limit: 255
     t.integer  "file_size"
     t.integer  "num_rows"
     t.text     "log"
@@ -763,17 +763,17 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "tenant_id"
-    t.string   "tenant_type"
+    t.string   "tenant_type",       limit: 255
   end
 
   create_table "logistics_vehicles", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "name"
-    t.string   "category"
-    t.string   "address"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
+    t.string   "name",       limit: 255
+    t.string   "category",   limit: 255
+    t.string   "address",    limit: 255
+    t.string   "city",       limit: 255
+    t.string   "state",      limit: 255
+    t.string   "zip",        limit: 255
     t.float    "lat"
     t.float    "lng"
     t.datetime "created_at"
@@ -782,9 +782,9 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "lookups", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "scope"
-    t.string   "name",       null: false
-    t.string   "value",      null: false
+    t.string   "scope",      limit: 255
+    t.string   "name",       limit: 255, null: false
+    t.string   "value",      limit: 255, null: false
     t.integer  "ordinal"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -796,23 +796,23 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.integer  "region_id"
     t.datetime "begins"
     t.datetime "ends"
-    t.string   "cookie_code"
+    t.string   "cookie_code",    limit: 255
     t.text     "html"
-    t.string   "dialog_class"
+    t.string   "dialog_class",   limit: 255
     t.integer  "cookie_version"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "path_regex_raw"
+    t.string   "path_regex_raw", limit: 255
   end
 
   add_index "motds", ["region_id"], name: "index_motds_on_region_id", using: :btree
 
   create_table "named_queries", force: :cascade do |t|
-    t.string   "name"
-    t.string   "token"
+    t.string   "name",       limit: 255
+    t.string   "token",      limit: 255
     t.text     "parameters"
-    t.string   "controller"
-    t.string   "action"
+    t.string   "controller", limit: 255
+    t.string   "action",     limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -820,12 +820,12 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "named_queries", ["name", "token"], name: "index_named_queries_on_name_and_token", using: :btree
 
   create_table "partners_partners", force: :cascade do |t|
-    t.string   "name"
-    t.string   "address1"
-    t.string   "address2"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
+    t.string   "name",       limit: 255
+    t.string   "address1",   limit: 255
+    t.string   "address2",   limit: 255
+    t.string   "city",       limit: 255
+    t.string   "state",      limit: 255
+    t.string   "zip",        limit: 255
     t.float    "lat"
     t.float    "lng"
     t.datetime "created_at"
@@ -836,8 +836,8 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "partners_partners", ["region_id"], name: "index_partners_partners_on_region_id", using: :btree
 
   create_table "roster_capabilities", force: :cascade do |t|
-    t.string   "name"
-    t.string   "grant_name"
+    t.string   "name",       limit: 255
+    t.string   "grant_name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -845,19 +845,19 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "roster_capability_memberships", force: :cascade do |t|
     t.integer "capability_id"
     t.integer "position_id"
-    t.string  "description"
+    t.string  "description",   limit: 255
   end
 
   create_table "roster_capability_scopes", force: :cascade do |t|
-    t.string   "scope"
+    t.string   "scope",                    limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "capability_membership_id"
   end
 
   create_table "roster_cell_carriers", force: :cascade do |t|
-    t.string   "name"
-    t.string   "sms_gateway"
+    t.string   "name",        limit: 255
+    t.string   "sms_gateway", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "pager"
@@ -866,25 +866,25 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "roster_people", force: :cascade do |t|
     t.integer  "region_id"
     t.integer  "primary_shift_territory_id"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "email"
-    t.string   "secondary_email"
-    t.string   "username"
-    t.string   "home_phone"
-    t.string   "cell_phone"
-    t.string   "work_phone"
-    t.string   "alternate_phone"
-    t.string   "sms_phone"
-    t.string   "phone_1_preference"
-    t.string   "phone_2_preference"
-    t.string   "phone_3_preference"
-    t.string   "phone_4_preference"
-    t.string   "address1"
-    t.string   "address2"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
+    t.string   "first_name",                 limit: 255
+    t.string   "last_name",                  limit: 255
+    t.string   "email",                      limit: 255
+    t.string   "secondary_email",            limit: 255
+    t.string   "username",                   limit: 255
+    t.string   "home_phone",                 limit: 255
+    t.string   "cell_phone",                 limit: 255
+    t.string   "work_phone",                 limit: 255
+    t.string   "alternate_phone",            limit: 255
+    t.string   "sms_phone",                  limit: 255
+    t.string   "phone_1_preference",         limit: 255
+    t.string   "phone_2_preference",         limit: 255
+    t.string   "phone_3_preference",         limit: 255
+    t.string   "phone_4_preference",         limit: 255
+    t.string   "address1",                   limit: 255
+    t.string   "address2",                   limit: 255
+    t.string   "city",                       limit: 255
+    t.string   "state",                      limit: 255
+    t.string   "zip",                        limit: 255
     t.integer  "vc_id"
     t.integer  "vc_member_number"
     t.integer  "home_phone_carrier_id"
@@ -897,8 +897,8 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.boolean  "cell_phone_disable"
     t.boolean  "alternate_phone_disable"
     t.boolean  "sms_phone_disable"
-    t.string   "encrypted_password"
-    t.string   "password_salt"
+    t.string   "encrypted_password",         limit: 255
+    t.string   "password_salt",              limit: 255
     t.binary   "persistence_token"
     t.datetime "last_login"
     t.datetime "vc_imported_at"
@@ -906,13 +906,13 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.datetime "updated_at"
     t.float    "lat"
     t.float    "lng"
-    t.boolean  "vc_is_active",               default: true
-    t.string   "gap_primary"
-    t.string   "gap_secondary"
-    t.string   "gap_tertiary"
+    t.boolean  "vc_is_active",                           default: true
+    t.string   "gap_primary",                limit: 255
+    t.string   "gap_secondary",              limit: 255
+    t.string   "gap_tertiary",               limit: 255
     t.datetime "vc_last_login"
     t.datetime "vc_last_profile_update"
-    t.string   "rco_id"
+    t.string   "rco_id",                     limit: 255
   end
 
   add_index "roster_people", ["region_id", "vc_is_active"], name: "index_roster_people_on_region_active", using: :btree
@@ -928,12 +928,12 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "roster_positions", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "name"
-    t.string   "vc_regex_raw"
+    t.string   "name",         limit: 255
+    t.string   "vc_regex_raw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "hidden",       default: false
-    t.string   "abbrev"
+    t.boolean  "hidden",                   default: false
+    t.string   "abbrev",       limit: 255
   end
 
   create_table "roster_positions_scheduler_shifts", id: false, force: :cascade do |t|
@@ -944,18 +944,18 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "roster_positions_scheduler_shifts", ["shift_id", "position_id"], name: "index_roster_positions_scheduler_shifts", unique: true, using: :btree
 
   create_table "roster_regions", force: :cascade do |t|
-    t.string   "name"
-    t.string   "code"
-    t.string   "short_name"
-    t.string   "time_zone_raw"
+    t.string   "name",                        limit: 255
+    t.string   "code",                        limit: 255
+    t.string   "short_name",                  limit: 255
+    t.string   "time_zone_raw",               limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "vc_username"
-    t.string   "vc_password"
-    t.string   "vc_position_filter"
+    t.string   "vc_username",                 limit: 255
+    t.string   "vc_password",                 limit: 255
+    t.string   "vc_position_filter",          limit: 255
     t.hstore   "config"
     t.integer  "vc_unit"
-    t.string   "url_slug"
+    t.string   "url_slug",                    limit: 255
     t.integer  "incident_number_sequence_id"
   end
 
@@ -963,15 +963,15 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "roster_shift_territories", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "name"
-    t.string   "abbrev"
-    t.string   "county_code"
-    t.string   "fips_code"
-    t.string   "gis_name"
-    t.string   "vc_regex_raw"
+    t.string   "name",         limit: 255
+    t.string   "abbrev",       limit: 255
+    t.string   "county_code",  limit: 255
+    t.string   "fips_code",    limit: 255
+    t.string   "gis_name",     limit: 255
+    t.string   "vc_regex_raw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "enabled",      default: true
+    t.boolean  "enabled",                  default: true
   end
 
   create_table "roster_shift_territory_memberships", force: :cascade do |t|
@@ -1000,7 +1000,7 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.boolean  "is_active"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name",               null: false
+    t.string   "name",               limit: 255, null: false
     t.integer  "shift_first_id"
     t.integer  "shift_second_id"
     t.integer  "shift_third_id"
@@ -1044,10 +1044,10 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   create_table "scheduler_notification_settings", force: :cascade do |t|
     t.integer  "email_advance_hours"
     t.integer  "sms_advance_hours"
-    t.integer  "sms_only_after",            default: 0
-    t.integer  "sms_only_before",           default: 86400
+    t.integer  "sms_only_after",                        default: 0
+    t.integer  "sms_only_before",                       default: 86400
     t.boolean  "send_email_invites"
-    t.string   "calendar_api_token"
+    t.string   "calendar_api_token",        limit: 255
     t.text     "shift_notification_phones"
     t.boolean  "email_swap_requested"
     t.boolean  "email_all_swaps"
@@ -1085,8 +1085,8 @@ ActiveRecord::Schema.define(version: 20200616210846) do
 
   create_table "scheduler_shift_categories", force: :cascade do |t|
     t.integer  "region_id"
-    t.string   "name"
-    t.boolean  "show",       default: false, null: false
+    t.string   "name",       limit: 255
+    t.boolean  "show",                   default: false, null: false
     t.integer  "ordinal"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1095,20 +1095,20 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "scheduler_shift_categories", ["region_id"], name: "index_scheduler_shift_categories_on_region_id", using: :btree
 
   create_table "scheduler_shift_times", force: :cascade do |t|
-    t.string   "name"
-    t.string   "period"
+    t.string   "name",             limit: 255
+    t.string   "period",           limit: 255
     t.integer  "start_offset"
     t.integer  "end_offset"
     t.integer  "region_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "active_sunday",    default: true, null: false
-    t.boolean  "active_monday",    default: true, null: false
-    t.boolean  "active_tuesday",   default: true, null: false
-    t.boolean  "active_wednesday", default: true, null: false
-    t.boolean  "active_thursday",  default: true, null: false
-    t.boolean  "active_friday",    default: true, null: false
-    t.boolean  "active_saturday",  default: true, null: false
+    t.boolean  "active_sunday",                default: true, null: false
+    t.boolean  "active_monday",                default: true, null: false
+    t.boolean  "active_tuesday",               default: true, null: false
+    t.boolean  "active_wednesday",             default: true, null: false
+    t.boolean  "active_thursday",              default: true, null: false
+    t.boolean  "active_friday",                default: true, null: false
+    t.boolean  "active_saturday",              default: true, null: false
   end
 
   add_index "scheduler_shift_times", ["region_id"], name: "index_scheduler_shift_times_on_region_id", using: :btree
@@ -1121,8 +1121,8 @@ ActiveRecord::Schema.define(version: 20200616210846) do
   add_index "scheduler_shift_times_shifts", ["shift_id", "shift_time_id"], name: "idx_scheduler_shift_times_shifts_unique", unique: true, using: :btree
 
   create_table "scheduler_shifts", force: :cascade do |t|
-    t.string   "name"
-    t.string   "abbrev"
+    t.string   "name",                     limit: 255
+    t.string   "abbrev",                   limit: 255
     t.integer  "max_signups"
     t.integer  "shift_territory_id"
     t.integer  "ordinal"
@@ -1135,30 +1135,36 @@ ActiveRecord::Schema.define(version: 20200616210846) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "min_desired_signups"
-    t.boolean  "ignore_shift_territory",   default: false
-    t.integer  "min_advance_signup",       default: 0,     null: false
+    t.boolean  "ignore_shift_territory",               default: false
+    t.integer  "min_advance_signup",                   default: 0,     null: false
     t.integer  "shift_category_id"
-    t.boolean  "exclusive",                default: true,  null: false
-    t.string   "vc_hours_type"
-    t.boolean  "show_in_dispatch_console", default: true,  null: false
+    t.boolean  "exclusive",                            default: true,  null: false
+    t.string   "vc_hours_type",            limit: 255
+    t.boolean  "show_in_dispatch_console",             default: true,  null: false
   end
 
   add_index "scheduler_shifts", ["shift_territory_id"], name: "index_scheduler_shifts_on_shift_territory_id", using: :btree
 
   create_table "versions", force: :cascade do |t|
-    t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
-    t.string   "event",          null: false
-    t.string   "whodunnit"
+    t.string   "item_type",      limit: 255, null: false
+    t.integer  "item_id",                    null: false
+    t.string   "event",          limit: 255, null: false
+    t.string   "whodunnit",      limit: 255
     t.text     "object"
     t.datetime "created_at"
     t.text     "object_changes"
-    t.string   "root_type"
+    t.string   "root_type",      limit: 255
     t.integer  "root_id"
-    t.integer  "region_id",      null: false
+    t.integer  "region_id",                  null: false
   end
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   add_index "versions", ["region_id", "root_type", "root_id"], name: "index_versions_on_region_id_root_type_root_id", using: :btree
 
+  add_foreign_key "incidents_dat_incidents", "incidents_incidents", column: "incident_id", name: "incidents_ref"
+  add_foreign_key "roster_position_memberships", "roster_people", column: "person_id", name: "person_id_ref", on_delete: :cascade
+  add_foreign_key "roster_shift_territory_memberships", "roster_people", column: "person_id", name: "person_id_ref", on_delete: :cascade
+  add_foreign_key "scheduler_shift_assignments", "roster_people", column: "person_id", name: "person_id_ref", on_delete: :cascade
+  add_foreign_key "scheduler_shift_assignments", "scheduler_shift_times", column: "shift_time_id", name: "shift_group_id_ref"
+  add_foreign_key "scheduler_shift_assignments", "scheduler_shifts", column: "shift_id", name: "shift_id_ref"
 end

--- a/db/views/100_incident_data.sql
+++ b/db/views/100_incident_data.sql
@@ -3,8 +3,8 @@ CREATE VIEW reporting.incident_data AS
   SELECT 
     inc.region_id, inc.incident_number, inc.incident_type, di.incident_call_type, inc.status, inc.date,
     inc.address, inc.city, inc.state, inc.zip, inc.county, inc.lat, inc.lng,
-    di.units_destroyed, di.units_major, di.units_minor, di.units_affected, di.units_unknown,
-    di.units_destroyed + di.units_major + di.units_minor + di.units_affected AS units_total,
+    di.units_destroyed, di.units_major, di.units_minor, di.units_affected, di.units_unknown, di.units_livable, di.units_not_livable,
+    di.units_destroyed + di.units_major + di.units_minor + di.units_affected + di.units_livable + di.units_not_livable + d AS units_total,
     inc.num_adults + inc.num_children as num_people, inc.num_adults, inc.num_children,
     di.num_people_injured, di.num_people_hospitalized, di.num_people_deceased, di.num_people_missing,
     inc.cas_event_number, inc.cas_event_id, inc.num_cases as num_cases_in_cas,

--- a/spec/factories/incidents/incidents_dat_incidents.rb
+++ b/spec/factories/incidents/incidents_dat_incidents.rb
@@ -10,6 +10,8 @@ FactoryGirl.define do
     incident_call_type 'hot'
     structure_type 'apartment'
 
+    units_not_livable 10
+    units_livable 10
     units_affected 10
     units_minor 10
     units_major 10
@@ -19,7 +21,7 @@ FactoryGirl.define do
     num_people_hospitalized 5
     num_people_deceased 5
 
-    services ['food']
+    services ['immediate']
     #resources( {'comfort_kits' => 1, 'blankets' => 10})
     comfort_kits 1
     blankets 10

--- a/spec/features/incidents/incidents_editable_spec.rb
+++ b/spec/features/incidents/incidents_editable_spec.rb
@@ -23,10 +23,8 @@ describe "Invalid Incident Report", :type => :feature do
 
     open_panel "Damage Assessment"
     select 'Apartment', from: 'Structure type*'
-    fill_in 'Units affected*', with: 1
-    fill_in 'Units minor*', with: 1
-    fill_in 'Units major*', with: 1
-    fill_in 'Units destroyed*', with: 1
+    fill_in 'Units not livable*', with: 1
+    fill_in 'Units livable*', with: 1
     click_button "Update Incident"
 
     open_panel "Demographics"

--- a/spec/features/incidents/submit_dat_incident_report_spec.rb
+++ b/spec/features/incidents/submit_dat_incident_report_spec.rb
@@ -71,10 +71,8 @@ describe "DAT Incident Report", type: :feature, versions: true do
     click_button 'Look Up Address'
 
     select 'Apartment', from: 'Structure type*'
-    fill_in 'Units affected*', with: 1
-    fill_in 'Units minor*', with: 1
-    fill_in 'Units major*', with: 1
-    fill_in 'Units destroyed*', with: 1
+    fill_in 'Units not livable*', with: 1
+    fill_in 'Units livable*', with: 1
 
     # Need the times here
     t = @region.time_zone.now

--- a/spec/features/incidents/submit_dat_incident_report_spec.rb
+++ b/spec/features/incidents/submit_dat_incident_report_spec.rb
@@ -17,7 +17,8 @@ describe "DAT Incident Report", type: :feature, versions: true do
 
     FactoryGirl.create :flex_schedule, person: @flex_responder
 
-    @incident = FactoryGirl.create :raw_incident, region: @person.region, shift_territory: @person.shift_territories.first
+    @incident = FactoryGirl.create :raw_incident, region: @person.region, shift_territory: @person.shift_territories.first, date:  Date.parse('2020-08-01')
+
 
     navigate_to_incident
     #visit "/incidents/incidents/#{@incident.incident_number}/dat/new"
@@ -56,6 +57,7 @@ describe "DAT Incident Report", type: :feature, versions: true do
   end
 
   def fill_in_details
+    save_page
 
     select 'Flood', from: 'Incident type*'
     select 'Cold', from: 'Incident call type*'
@@ -71,8 +73,11 @@ describe "DAT Incident Report", type: :feature, versions: true do
     click_button 'Look Up Address'
 
     select 'Apartment', from: 'Structure type*'
+
+    page.should_not have_text "Units affected"
     fill_in 'Units not livable*', with: 1
     fill_in 'Units livable*', with: 1
+    save_page
 
     # Need the times here
     t = @region.time_zone.now

--- a/spec/features/incidents/view_incident_spec.rb
+++ b/spec/features/incidents/view_incident_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe "View Incident Report", :type => :feature do
+  before do
+    FactoryGirl.create :incidents_scope, region: @person.region
+  end
+
+  it "Should be viewable" do
+    incident = FactoryGirl.create :incident, region: @person.region, date: Date.current
+    FactoryGirl.create :dat_incident, incident: incident
+
+    visit "/incidents/#{@person.region.url_slug}/incidents/#{incident.incident_number}"
+
+    # Relating to issue #173
+    page.should have_text "Destroyed"
+    page.should have_text "Affected"
+    page.should have_text "Minor"
+    page.should have_text "Major"
+    page.should have_text "Livable"
+    page.should have_text "Not Livable"
+  end
+
+  # Relating to issue #173
+  it "Should not have old damage assesments" do
+    incident = FactoryGirl.create :incident, region: @person.region, date: Date.current
+    FactoryGirl.create :dat_incident, incident: incident,
+      units_destroyed: 0,
+      units_affected: 0,
+      units_minor: 0,
+      units_major: 0,
+      units_livable: 0,
+      units_not_livable: 0
+
+    visit "/incidents/#{@person.region.url_slug}/incidents/#{incident.incident_number}"
+
+    page.should_not have_text "Destroyed"
+    page.should_not have_text "Affected"
+    page.should_not have_text "Minor"
+    page.should_not have_text "Major"
+    page.should have_text "Livable"
+    page.should have_text "Not Livable"
+  end
+end


### PR DESCRIPTION
Closes #173. Adds `units_not_livable` and `units_livable` as additional fields for the damage assessment reports. Leaves the existing fields in place, but makes them optional to allow for a transition.

@OhMcGoo based on the conversations we've had this should allow for a transition by making the old fields optional. It may be worth flagging that this could change things for reporting, but I'll be updating the view in the SQL file after merging. This should be ready to deploy whenever is convenient for you