### PR TITLE
Fix #201: Allow incidents to be closed without completion

### DIFF
--- a/app/controllers/incidents/incidents_controller.rb
+++ b/app/controllers/incidents/incidents_controller.rb
@@ -11,7 +11,7 @@ class Incidents::IncidentsController < Incidents::BaseController
   responders :partial
 
   actions :all, except: :index
-  custom_actions collection: [:needs_report, :activity, :map], resource: [:mark_invalid, :close, :reopen]
+  custom_actions collection: [:needs_report, :activity, :map], resource: [:mark_invalid, :close, :force_close, :reopen]
 
   include HasManyRoutesFor
   has_many_routes_for :responder_messages, :dat, :event_logs, :responders, :attachments, :notifications, :cases, :initial_incident_report
@@ -40,6 +40,11 @@ class Incidents::IncidentsController < Incidents::BaseController
     else
       redirect_to edit_resource_dat_path(status: 'closed')
     end
+  end
+
+  def force_close
+    resource.force_close!
+    redirect_to resource_path
   end
 
   def reopen

--- a/app/models/incidents/incident.rb
+++ b/app/models/incidents/incident.rb
@@ -198,4 +198,10 @@ class Incidents::Incident < ActiveRecord::Base
     dat_incident && dat_incident.valid? && save
   end
 
+  def force_close!
+    self.status = 'closed'
+    self.response_date = region.time_zone.today
+    save(:validate => false)
+  end
+
 end

--- a/app/views/incidents/incidents/_needs_report_table.html.haml
+++ b/app/views/incidents/incidents/_needs_report_table.html.haml
@@ -13,7 +13,7 @@
     -needs_report_collection.each do |inc|
       - inc = Incidents::IncidentPresenter.new inc
       %tr
-        %td=inc.incident_number
+        %td=link_to inc.incident_number, inc.path
         %td=inc.full_address
         %td
           =inc.region.try :name

--- a/app/views/incidents/incidents/show.html.haml
+++ b/app/views/incidents/incidents/show.html.haml
@@ -8,6 +8,8 @@
     -if resource.open_incident?
       -if can? :close, resource
         =link_to 'Close/Submit', close_resource_path, class: 'btn btn-default', method: 'post', data: {confirm: 'Really close this incident?'}
+      -if can? :close_without_completing, resource
+        =link_to 'Close Without Completion', force_close_resource_path, class: 'btn btn-default', method: 'post', data: {confirm: 'Really close this incident even if not complete?'}
       -if can? :mark_invalid, resource
         =link_to 'Invalid/No Response', mark_invalid_resource_path, class: 'btn btn-danger'
     -else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Scheduler::Application.routes.draw do
         member do
           match :mark_invalid, via: [:get, :post, :put, :patch]
           match :close, via: [:post, :put, :patch]
+          match :force_close, via: [:post, :put, :patch]
           match :reopen, via: [:post, :put, :patch]
         end
       end

--- a/spec/features/incidents/submit_dat_incident_report_spec.rb
+++ b/spec/features/incidents/submit_dat_incident_report_spec.rb
@@ -50,6 +50,30 @@ describe "DAT Incident Report", type: :feature, versions: true do
 
   end
 
+  it "Can be foceably closed" do
+    grant_capability! 'incidents_admin'
+
+    @region = @person.region
+    FactoryGirl.create :incidents_scope, region: @person.region
+
+    @incident = FactoryGirl.create :raw_incident,
+      region: @person.region,
+      shift_territory: @person.shift_territories.first,
+      date: Date.current,
+      city: "Test City"
+
+    visit "/incidents/#{@region.url_slug}"
+    click_on "Test City"
+
+    accept_confirm do
+      click_on "Close Without Completion"
+    end
+
+    page.should have_text("Reopen")
+
+    expect(@incident.reload.status).to eq('closed')
+  end
+
   def navigate_to_incident
     visit "/incidents/#{@region.url_slug}"
     click_on "Test City"


### PR DESCRIPTION
For admins, add a buton that forces an incident to close without fully
submitting all the validating information needed for it.

This also adds a small change, adding a link from Currently Open
Incidents to the incident pages for easier navigating.

Issue #201: Create a way for closing open incident reports listed
            on the Currently Open Incidents page without having to
            complete all mandatory fields