### PR TITLE
Fix #212: Update dispatched incident text

### DIFF
--- a/app/views/incidents/dispatch_intake/show.html.haml
+++ b/app/views/incidents/dispatch_intake/show.html.haml
@@ -13,5 +13,5 @@
           Thank you.  We have assigned number #{resource.incident.incident_number} to your call.  If you need to follow up, please use this number.
       %p
         %strong
-          A Red Cross responder should return your call within 10-15 minutes to confirm the details and our estimated time of arrival if appropriate.
+          Please immediately alert the Region to this incident so they can initiate the response. Return to the Dispatch Console using the button below and locate your incident at the top of the list. Click “Show” to see the phone number for the on-call person in that Chapter and call them with the incident details immediately. Continue calling through the list until you speak to a member of the Regional team.
     =link_to "Back to Dispatch Console", incidents_region_dispatch_index_path(parent), class: "btn btn-primary"

--- a/spec/features/incidents/dispatch_intake_spec.rb
+++ b/spec/features/incidents/dispatch_intake_spec.rb
@@ -74,7 +74,7 @@ describe "Incident Dispatch Intake Console", :type => :feature do
     fill_in "Are there any special instructions or specific services you are requesting?", with: Faker::Lorem.paragraph
     click_on "Create Incident"
 
-    page.should have_text "A Red Cross responder should return your call"
+    page.should have_text "Please immediately alert the Region to this incident so they"
 
     log = Incidents::CallLog.last!
     expect(log.call_type).to eq "incident"
@@ -104,7 +104,7 @@ describe "Incident Dispatch Intake Console", :type => :feature do
     fill_in "Are there any special instructions or specific services you are requesting?", with: Faker::Lorem.paragraph
     click_on "Create Incident"
 
-    page.should have_text "A Red Cross responder should return your call"
+    page.should have_text "Please immediately alert the Region to this incident so they"
   end
 
 


### PR DESCRIPTION
Issue #212: On the page presented after a new incident is created
            using the NorCen Dispatch Console, modify text