### PR TITLE
Fix #141: Change recruitment textbox to textarea

### DIFF
--- a/app/helpers/editable_helper.rb
+++ b/app/helpers/editable_helper.rb
@@ -30,7 +30,7 @@ module EditableHelper
     editable_select(resource, name, options, *args)
   end
 
-  def editable_string(resource, name, url: nil, editable: nil, **options)
+  def editable_string(resource, name, url: nil, editable: nil, type: 'text', **options)
     if editable==nil
       editable = can? :update, resource
     end
@@ -38,7 +38,7 @@ module EditableHelper
       model_name = resource.class.model_name.param_key
       attr_name = "#{model_name}_#{name}-#{resource.id}"
       url ||= send "#{model_name}_path", resource
-      link_to((resource.send(name) || ""), "#", id: attr_name, data: {name: name, type: 'text', resource: model_name, url: url}.reverse_merge(options)) <<
+      link_to((resource.send(name) || ""), "#", id: attr_name, data: {name: name, type: type, resource: model_name, url: url}.reverse_merge(options)) <<
       javascript_tag("$('##{attr_name}').editable()")
     else
       resource.send(name)

--- a/app/views/incidents/responders/index.html.haml
+++ b/app/views/incidents/responders/index.html.haml
@@ -25,7 +25,7 @@
         -#  =check_box_tag :ignore_area, '1', ignore_area
         -#  =submit_tag 'Filter', class: 'btn btn-mini'
         Recruitment message:
-        =editable_string parent, :recruitment_message, url: parent_path
+        =editable_string parent, :recruitment_message, url: parent_path, type: 'textarea'
       .responders-table{data: {refresh_name: "recruitment", refresh: url_for(partial: 'responders_table')}}
         =render 'responders_table'
 

--- a/spec/features/incidents/responders_console_spec.rb
+++ b/spec/features/incidents/responders_console_spec.rb
@@ -76,7 +76,7 @@ describe "Incident Responders Console", :type => :feature do
     # Set recruit message
     message = Faker::Lorem.sentence
     click_link "Empty"
-    find(".editable-input input").set message
+    find(".editable-input textarea").set message
     find(".editable-buttons .editable-submit").click
     expect(page).to have_text message
     


### PR DESCRIPTION
Issue #141: In the Responder Console, increase the size of the Recruitment
            message window so that the full message can be seen and edited