### PR TITLE
Fix #140: Create actions menu for responders console

### DIFF
--- a/app/helpers/incidents/responders_helper.rb
+++ b/app/helpers/incidents/responders_helper.rb
@@ -13,25 +13,8 @@ module Incidents::RespondersHelper
     end
   end
 
-  def person_schedule_row obj, editable = nil
-    person_row(obj, obj.person, editable)
-  end
-
-  def person_row(obj, person, editable = nil)
-    editable = can?( :create, parent.responder_assignments.build( person: person)) if editable == nil
-
-    content_tag :tr, class: 'person', data: {person: person_json(person, obj, editable), person_id: person.id} do
-      safe_join([
-        content_tag(:td, role_name(obj)),
-        content_tag(:td, qualifications(person)),
-        content_tag(:td, person.full_name),
-        content_tag(:td, location(person)),
-        tag(:td, class: 'distance'),
-        tag(:td, class: 'travel-time'),
-        content_tag(:td, recruit_action(person, editable)),
-        content_tag(:td, links(person, obj, editable))
-      ])
-    end
+  def person_editable(person)
+     can?( :create, parent.responder_assignments.build( person: person))
   end
 
   def links(person, obj, editable)
@@ -49,8 +32,12 @@ module Incidents::RespondersHelper
     if recruitment
       existing_recruit_status recruitment
     elsif parent.region.incidents_enable_messaging && person.sms_addresses.present? && editable
-      link_to 'Send SMS', incidents_region_incident_responder_recruitments_path(parent.region, parent, person_id: person.id), method: :post, remote: true
+      recruitment_message_link person
     end
+  end
+
+  def recruitment_message_link person
+      link_to 'Send Recruitment Message', incidents_region_incident_responder_recruitments_path(parent.region, parent, person_id: person.id), method: :post, remote: true
   end
 
   def existing_recruit_status recruitment

--- a/app/views/incidents/responders/_person_row.html.haml
+++ b/app/views/incidents/responders/_person_row.html.haml
@@ -1,0 +1,26 @@
+- editable = person_editable(person)
+- has_sms = person.sms_addresses.present?
+%tr.person{data: {person: person_json(person, obj, editable), person_id: person.id}}
+  %td
+    =role_name(obj)
+  %td
+    =qualifications(person)
+  %td
+    =person.full_name
+  %td
+    =location(person)
+  %td.distance
+  %td.travel-time
+  %td
+    =recruit_action(person, editable)
+  %td
+    .btn-group
+      =link_to '#', class: "btn btn-default btn-sm dropdown-toggle", data: {toggle: 'dropdown'} do
+        Actions
+        %span.caret
+      %ul.dropdown-menu{role: "menu", aria_labelledby: "dropdownMenu"}
+        %li=links(person, obj, editable)
+        -if enable_messaging && has_sms
+          %li=recruitment_message_link(person)
+        -if enable_messaging && has_sms
+          %li=link_to 'Send Message', '#', data: {edit_panel: new_incidents_region_incident_responder_message_path(parent.region, parent, recipient: person.id)}

--- a/app/views/incidents/responders/_responders_table.html.haml
+++ b/app/views/incidents/responders/_responders_table.html.haml
@@ -20,27 +20,27 @@
             %a{data: {toggle: 'collapse', target: 'tbody.dispatch-list'}} show dispatch list
     %tbody.dispatch-list{class: dispatched && "collapse"}
       - service.dispatch_shifts.each do |assignment|
-        =person_schedule_row(assignment)
+        =render partial: 'person_row', locals: {person: assignment.person, obj: assignment}
       - service.dispatch_backup.each do |person|
-        =person_row("Backup", person)
+        =render partial: 'person_row', locals: {person: person, obj: "Backup"}
   %tbody
     %tr
       %th(colspan=8) Scheduled
   %tbody.responders-list.sort
     - service.scheduled_responders.each do |schedule|
-      =person_schedule_row(schedule)
+      =render partial: 'person_row', locals: {person: schedule.person, obj: schedule}
   %tbody
     %tr
       %th(colspan=8) Flex
   %tbody.responders-list.sort
     - service.flex_responders.each do |flex|
-      =person_schedule_row(flex)
+      =render partial: 'person_row', locals: {person: flex.person, obj: flex}
   %tbody
     %tr
       %th(colspan=8) Decline
   %tbody.responders-list.not-available.sort
     - collection.reject(&:was_available).each do |ass|
-      =person_schedule_row(ass)
+      =render partial: 'person_row', locals: {person: ass.person, obj: ass}
 
 :javascript
   if (window.respondersController) {

--- a/spec/features/incidents/responders_console_spec.rb
+++ b/spec/features/incidents/responders_console_spec.rb
@@ -53,7 +53,8 @@ describe "Incident Responders Console", :type => :feature do
     expect(page).to have_text(@committed_responder.full_name)
 
     within 'tr', text: @committed_responder.full_name do
-      click_link "Assign"
+      click_on "Actions"
+      click_on "Assign"
     end
     select "Team Lead", from: 'Response*'
     check "Send assignment sms"
@@ -62,6 +63,7 @@ describe "Incident Responders Console", :type => :feature do
     expect(find(".assigned-table")).to have_text(@committed_responder.full_name)
 
     within 'tr', text: @flex_responder.full_name do
+      click_on "Actions"
       click_link "Assign"
     end
     select "Not Available", from: "Response*"
@@ -81,7 +83,7 @@ describe "Incident Responders Console", :type => :feature do
     expect(page).to have_text message
     
     within 'tbody.responders-list tr', text: @committed_responder.full_name do
-      click_link "Send SMS"
+      click_link "Send Recruitment Message"
     end
 
     expect(find("tbody.responders-list tr", text: @committed_responder.full_name)).to have_text "Message Sent"

--- a/spec/helpers/incidents/responders_helper_spec.rb
+++ b/spec/helpers/incidents/responders_helper_spec.rb
@@ -36,50 +36,51 @@ describe Incidents::RespondersHelper, :type => :helper do
     end
   end
 
+  # This really tests the helpers that are called from the _person_row partial
   describe "#person_schedule_row" do
     it "should return html" do
-      res = helper.person_schedule_row(assignment, true)
+      res = helper.links(person, assignment, true)
       expect(res).to be_a(ActiveSupport::SafeBuffer)
     end
 
     it "should link to a new assignment" do
-      res = helper.person_schedule_row(assignment, true)
+      res = helper.links(person, assignment, true)
       expect(res).to match(%r[responders/new\?person_id=#{person.id}])
     end
 
     it "should link to an existing assignment" do
       assignment = FactoryGirl.create :responder_assignment, person: person
-      res = helper.person_schedule_row(assignment, true)
+      res = helper.links(person, assignment, true)
       expect(res).to match(%r[responders/#{assignment.id}/edit])
-      expect(res).to match(assignment.humanized_role)
+      expect(role_name(assignment)).to match(assignment.humanized_role)
     end
 
     it "should provide the shift assignment name" do
       assignment = FactoryGirl.build_stubbed :shift_assignment, person: person
-      res = helper.person_schedule_row(assignment, true)
+      res = helper.role_name(assignment)
       expect(res).to match(assignment.shift.name)
     end
 
     it "should not link if not editable" do
-      res = helper.person_schedule_row(assignment, false)
+      res = helper.links(person, assignment, false)
       expect(res).not_to match(%r[responders/new\?person_id=#{person.id}])
     end
 
     it "should show message sent if a recruitment exists" do
       helper.stub recruitments: {person.id => [double(:recruitment, available?: false, unavailable?: false)]}
-      res = helper.person_schedule_row(assignment, true)
+      res = helper.recruit_action(person, true)
       expect(res).to match("Message Sent")
     end
 
     it "should show available if a recruitment exists" do
       helper.stub recruitments: {person.id => [double(:recruitment, available?: true, unavailable?: false)]}
-      res = helper.person_schedule_row(assignment, true)
+      res = helper.recruit_action(person, true)
       expect(res).to match("Available")
     end
 
     it "should show unavailable if a recruitment exists" do
       helper.stub recruitments: {person.id => [double(:recruitment, available?: false, unavailable?: true)]}
-      res = helper.person_schedule_row(assignment, true)
+      res = helper.recruit_action(person, true)
       expect(res).to match("Not Available")
     end
   end


### PR DESCRIPTION
Needed more actions for responders that are not yet assigned for more
messaging.

Issue #140: Permit resending of recruitment messages from the Responder
            Console and individual messaging to unassigned responders