### PR TITLE
Fix #254: Change MOTD default region name to All Regions

### DIFF
--- a/app/admin/motds.rb
+++ b/app/admin/motds.rb
@@ -5,4 +5,19 @@ ActiveAdmin.register MOTD, as: 'MOTD' do
       [params.fetch(resource_request_name, {}).permit(:region_id, :begins, :ends, :cookie_code, :html, :dialog_class, :cookie_version, :path_regex_raw)]
     end
   end
+
+  form do |f|
+    f.inputs do
+      f.input :region, :include_blank => "All Regions"
+      f.input :begins
+      f.input :ends
+      f.input :cookie_code
+      f.input :html
+      f.input :dialog_class
+      f.input :cookie_version
+      f.input :path_regex_raw
+    end
+    f.actions
+  end
+
 end


### PR DESCRIPTION
Because we wanted specific functionality on one of the options, we could
no longer use the activeadmin default functionality.  That required
recreating the default explicitly, and then modifying the 'region'
option to include a value for the blank value.

Issue #254: On admin MOTD, use "All Regions" (instead of blank)
            for global message.