### PR TITLE
Fix #148: Refactor roster query

### DIFF
--- a/app/views/scheduler/people/_index_table.html.haml
+++ b/app/views/scheduler/people/_index_table.html.haml
@@ -19,14 +19,14 @@
           %small
             = person.positions.select{|p|!p.hidden}.map(&:name).join ", "
         %td
-          = pluralize person.num_shifts, 'shift'
+          = pluralize num_shifts(person), 'shift'
         %td
-          -if d = person.prev_shift
+          -if d = prev_shift(person)
             =d.to_s :dow_short
             %br
             (#{(Date.current-d).to_i} days ago)
         %td
-          -if d = person.next_shift
+          -if d = next_shift(person)
             =d.to_s :dow_short
         %td
           -if d = person.last_login


### PR DESCRIPTION
The query to select all the rosters included some very expensive count
queries in the select portion.  Because these were running for all, even
before the offset/limit, they were taking too long and timing out in
production.  The quickest fix was to move them to their own queries
after the main query was run.

Issue #148: "Show Roster" hyperlink is malfunctioning