### PR TITLE
Fix #192: Enlarge "See All" link on dat schedulign page

### DIFF
--- a/app/views/scheduler/home/root.html.haml
+++ b/app/views/scheduler/home/root.html.haml
@@ -94,7 +94,7 @@
       %h5 
         %i.fa.fa-group
         Current On-Call Team:
-        %small=link_to 'See All', scheduler_on_call_path
+        %strong=link_to 'See All', scheduler_on_call_path
       - groups = Scheduler::ShiftTime.current_groups_for_region(current_region)
       - groups.select{|g| g.period == 'daily' }.each do |grp| 
         %strong=grp.start_date.to_s(:dow_long) + " - " + grp.name


### PR DESCRIPTION
Issue #192: On the DAT Scheduling page, next to Current On-Call Team, enlarge
            the "See all" link to the size of the adjacent text and make
            boldface