### PR TITLE
Fix #193: Remove days/months/etc from on_call schedule

### DIFF
--- a/app/views/scheduler/home/on_call.html.haml
+++ b/app/views/scheduler/home/on_call.html.haml
@@ -1,6 +1,2 @@
 - groups = Scheduler::ShiftTime.current_groups_for_region(current_person.region)
-- groups.select{|g| g.period == 'daily' }.each do |grp| 
-  %h2
-    On Call Schedule - 
-    =grp.start_date.to_s(:dow_long) + " - " + grp.name
 =render partial: 'current_shifts', locals: {shift_territories: current_region.shift_territories.enabled.to_a, groups: groups}


### PR DESCRIPTION
Issue #193: On the page accessed by clicking on the "See all" link on the DAT
            Scheduling page, delete "On Call Schedule," the days, months,
            dates and time block