### PR TITLE
Fix #194: Remove time areas under on call team on schedule page

### DIFF
--- a/app/views/scheduler/home/root.html.haml
+++ b/app/views/scheduler/home/root.html.haml
@@ -96,10 +96,6 @@
         Current On-Call Team:
         %small=link_to 'See All', scheduler_on_call_path
       - groups = Scheduler::ShiftTime.current_groups_for_region(current_region)
-      - groups.select{|g| g.period == 'daily' }.each do |grp| 
-        %strong=grp.start_date.to_s(:dow_long) + " - " + grp.name
-        %br
-      %br
       = render partial: 'current_shifts', locals: {shift_territories: current_person.shift_territories, groups: groups}
 
 .row


### PR DESCRIPTION
Issue #194: On the DAT Scheduling page, under to Current On-Call Team,
            delete the days, months, dates and time blocks