### PR TITLE
Fix #204: Update attachment max size to 5mb

### DIFF
--- a/app/models/incidents/attachment.rb
+++ b/app/models/incidents/attachment.rb
@@ -4,7 +4,7 @@ class Incidents::Attachment < Incidents::DataModel
 
   validates :incident, :name, presence: true
   validates_attachment :file, presence: true, 
-                              size: { in: 0..2.megabytes }
+                              size: { in: 0..5.megabytes }
   do_not_validate_attachment_file_type :file
 
 


### PR DESCRIPTION
Issue #204: In the Attachments section, increase the file size capacity