### PR TITLE
Fix #205: Add reason_marked_invalid to incident

### DIFF
--- a/app/controllers/incidents/dat_incidents_controller.rb
+++ b/app/controllers/incidents/dat_incidents_controller.rb
@@ -140,7 +140,7 @@ class Incidents::DatIncidentsController < Incidents::BaseController
       return [] if request.get?
 
       keys = [:incident_call_type, :team_lead_id, :num_cases, 
-             :incident_type, :incident_description, :narrative_brief, :narrative,
+             :incident_type, :reason_marked_invalid, :incident_description, :narrative_brief, :narrative,
              :num_people_injured, :num_people_hospitalized, :num_people_deceased, :num_people_missing,
              :responder_notified, :responder_arrived, :responder_departed,
              :units_affected, :units_minor, :units_major, :units_destroyed, :units_unknown,
@@ -171,7 +171,7 @@ class Incidents::DatIncidentsController < Incidents::BaseController
 
       base = params.require(:incidents_dat_incident).fetch(:incident_attributes, {})
       @_incident_params ||= base.permit([
-        :incident_type, :response_territory_id, :narrative, :status, :cas_event_number,
+        :incident_type, :reason_marked_invalid, :response_territory_id, :narrative, :status, :cas_event_number,
         :address, :city, :state, :zip, :lat, :lng, :county, :neighborhood, :address_directly_entered,
         :num_adults, :num_children, :num_families,
         {:team_lead_attributes => [:id, :person_id, :role, :response]},

--- a/app/controllers/incidents/incidents_controller.rb
+++ b/app/controllers/incidents/incidents_controller.rb
@@ -79,7 +79,7 @@ class Incidents::IncidentsController < Incidents::BaseController
   end
 
   def mark_invalid_params
-    params.require(:incidents_incident).permit(:incident_type, :narrative).merge(status: 'invalid')
+    params.require(:incidents_incident).permit(:reason_marked_invalid, :narrative).merge(status: 'invalid')
   end
 
   def require_open_incident    
@@ -159,7 +159,7 @@ class Incidents::IncidentsController < Incidents::BaseController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def resource_params
-      keys = [:response_territory_id, :date, :incident_type, :status, :narrative, :address, :city, :state, :zip, :neighborhood, :county, :lat, :lng, :address_directly_entered, :recruitment_message]
+      keys = [:response_territory_id, :date, :incident_type, :reason_marked_invalid, :status, :narrative, :address, :city, :state, :zip, :neighborhood, :county, :lat, :lng, :address_directly_entered, :recruitment_message]
 
       keys << :incident_number if params[:action] == 'create' && !has_incident_number_sequence?
 

--- a/app/models/incidents/incident.rb
+++ b/app/models/incidents/incident.rb
@@ -87,6 +87,10 @@ class Incidents::Incident < ActiveRecord::Base
     valid_incident_types
   end
 
+  assignable_values_for :reason_marked_invalid, allow_blank: true do
+    self.class.invalid_incident_types
+  end
+
   assignable_values_for :status do
     %w(open closed invalid)
   end

--- a/app/models/incidents/validators/invalid_incident_validator.rb
+++ b/app/models/incidents/validators/invalid_incident_validator.rb
@@ -2,6 +2,6 @@ class Incidents::Validators::InvalidIncidentValidator < DelegatedValidator
 
   self.target_class = Incidents::Incident
 
-  validates :incident_type, :narrative, presence: true
+  validates :reason_marked_invalid, :narrative, presence: true
 
 end

--- a/app/views/incidents/incidents/mark_invalid.html.haml
+++ b/app/views/incidents/incidents/mark_invalid.html.haml
@@ -5,7 +5,7 @@
       You have chosen to mark this incident as invalid, and it will be removed from the DCSOps system.
       This action can only be undone by a DAT Administrator.
       Are you sure you want to continue?
-    =f.input :incident_type, label: 'Reason', as: :assignable_select, humanized: :humanized_invalid_incident_types, include_blank: true
+    =f.input :reason_marked_invalid, label: 'Reason', as: :assignable_select, humanized: :humanized_invalid_incident_types, include_blank: true
     =f.input :narrative, label: 'Please Explain', as: :text, input_html: { rows: 5}
     =f.actions do
       =f.action :submit, button_html: {class: 'btn btn-danger'}, label: "Remove This Incident"

--- a/app/views/incidents/incidents_list/_index_table.html.haml
+++ b/app/views/incidents/incidents_list/_index_table.html.haml
@@ -21,5 +21,9 @@
       %td= resource.address
       %td= resource.city
       %td= resource.county
-      %td= resource.humanized_incident_type
+      %td
+        =resource.humanized_incident_type
+        -if resource.invalid_incident? and resource.reason_marked_invalid.present?
+          (#{resource.humanized_reason_marked_invalid})
+
 .text-center= paginate collection, :theme => 'twitter-bootstrap-3', remote: true

--- a/app/views/incidents/incidents_list/_statistics.html.haml
+++ b/app/views/incidents/incidents_list/_statistics.html.haml
@@ -8,7 +8,7 @@
         %td=num stats.incident_count
       %tr
         %th No Response
-        %td=num collection_for_stats.with_status('invalid').where{incident_type.in(['not_eligible_for_services', 'no_response_needed'])}.count
+        %td=num collection_for_stats.with_status('invalid').where{reason_marked_invalid.in(['not_eligible_for_services', 'no_response_needed'])}.count
       %tr
         %th Clients
         %td=num stats.client_count

--- a/app/views/incidents/notifications/mailer/incident_invalid.html.haml
+++ b/app/views/incidents/notifications/mailer/incident_invalid.html.haml
@@ -9,6 +9,6 @@
   %br
   Date and Time Created: #{@incident.created_at.to_s}
   %br
-  Invalid Type: #{@incident.humanized_incident_type}
+  Invalid Type: #{@incident.humanized_reason_marked_invalid}
   %br
   Reason: #{@incident.narrative}

--- a/app/views/incidents/notifications/mailer/incident_invalid_sms.text.haml
+++ b/app/views/incidents/notifications/mailer/incident_invalid_sms.text.haml
@@ -1,1 +1,1 @@
-Incident #{@incident.incident_number} in #{@incident.city}, #{@incident.state} (#{@incident.response_territory.name}) has been marked invalid: #{@incident.humanized_incident_type}.  View in DCSOps: #{@incident.path}
+Incident #{@incident.incident_number} in #{@incident.city}, #{@incident.state} (#{@incident.response_territory.name}) has been marked invalid: #{@incident.humanized_reason_marked_invalid}.  View in DCSOps: #{@incident.path}

--- a/db/migrate/20200710232343_add_reason_marked_invalid_to_incidents.rb
+++ b/db/migrate/20200710232343_add_reason_marked_invalid_to_incidents.rb
@@ -1,0 +1,5 @@
+class AddReasonMarkedInvalidToIncidents < ActiveRecord::Migration
+  def change
+    add_column :incidents_incidents, :reason_marked_invalid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -506,6 +506,7 @@ ActiveRecord::Schema.define(version: 20200726163705) do
     t.integer  "response_territory_id"
     t.integer  "current_dispatch_contact_id"
     t.datetime "dispatch_contact_due_at"
+    t.string   "reason_marked_invalid"
   end
 
   add_index "incidents_incidents", ["cas_event_number"], name: "index_incidents_incidents_on_cas_event_number", using: :btree

--- a/spec/controllers/incidents/incidents_controller_spec.rb
+++ b/spec/controllers/incidents/incidents_controller_spec.rb
@@ -63,7 +63,7 @@ describe Incidents::IncidentsController, :type => :controller do
     end
 
     it "should succeed as post with valid params" do
-      post :mark_invalid, id: inc.to_param, region_id: inc.region.to_param, incidents_incident: {incident_type: 'invalid', narrative: 'Test'}
+      post :mark_invalid, id: inc.to_param, region_id: inc.region.to_param, incidents_incident: {reason_marked_invalid: 'invalid', narrative: 'Test'}
       expect(response).to redirect_to("/incidents/#{inc.region.to_param}/incidents/needs_report")
       inc.reload
       expect(inc.status).to eq('invalid')
@@ -88,7 +88,7 @@ describe Incidents::IncidentsController, :type => :controller do
 
     it "should trigger the invalid notification" do
       expect(Incidents::Notifications::Notification).to receive(:create_for_event).with(anything, 'incident_invalid')
-      post :mark_invalid, id: inc.to_param, region_id: inc.region.to_param, incidents_incident: {incident_type: 'invalid', narrative: 'Test'}
+      post :mark_invalid, id: inc.to_param, region_id: inc.region.to_param, incidents_incident: {reason_marked_invalid: 'invalid', narrative: 'Test'}
     end
   end
 

--- a/spec/features/incidents/invalid_incident_spec.rb
+++ b/spec/features/incidents/invalid_incident_spec.rb
@@ -25,7 +25,6 @@ describe "Invalid Incident Report", :type => :feature do
     click_button 'Remove This Incident'
 
     expect(page).to have_text 'Currently Open Incidents'
-
-    expect(@incident.reload.incident_type).to eq('not_eligible_for_services')
+    expect(@incident.reload.reason_marked_invalid).to eq('not_eligible_for_services')
   end
 end


### PR DESCRIPTION
Before, the reason an incident was marked invalid was stored in the
incident_type field, which resulted in losing the original incident type
(fire, or vacate, or whatever).  This caused issues when the incident
was reopened, or for reporting.

Instead, we want to have a separate field for the invalid reason that we
display and search on when the incident status is 'invalid'

Issue #205: Create a Response Status field separate from Incident Types